### PR TITLE
Critical Security Fix: Enforce Sudo Permission Constraints (v1.5.3)

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -172,12 +172,19 @@ int main_loop(void) {
             continue;
         }
 
-        /* Check if user has privileges for this command */
+        /* Check if user has privileges for this specific command */
         if (!has_sudo_privileges && !is_safe_command(command_line)) {
             fprintf(stderr, "sudosh: %s is not in the sudoers file and '%s' is not a safe command\n",
                     username, command_line);
             fprintf(stderr, "Available safe commands: ls, pwd, whoami, id, date, uptime, w, who\n");
             log_security_violation(username, "attempted privileged command without sudoers access");
+            free(command_line);
+            continue;
+        } else if (has_sudo_privileges && !check_command_permission(username, command_line)) {
+            /* User has sudo privileges but not for this specific command */
+            fprintf(stderr, "sudosh: %s is not allowed to run '%s' according to sudoers configuration\n",
+                    username, command_line);
+            log_security_violation(username, "attempted command not permitted by sudoers");
             free(command_line);
             continue;
         }

--- a/src/sudosh.h
+++ b/src/sudosh.h
@@ -56,6 +56,9 @@ extern char **environ;
 /* Global verbose flag */
 extern int verbose_mode;
 
+/* Global test mode flag */
+extern int test_mode;
+
 /* Configuration constants */
 #define MAX_COMMAND_LENGTH 4096
 #define MAX_USERNAME_LENGTH 256
@@ -251,6 +254,7 @@ struct user_info *get_user_info_sssd(const char *username);
 
 /* Enhanced privilege checking */
 int check_sudo_privileges_enhanced(const char *username);
+int check_command_permission(const char *username, const char *command);
 
 /* List available commands */
 void list_available_commands(const char *username);

--- a/src/sudosh.h
+++ b/src/sudosh.h
@@ -63,7 +63,7 @@ extern int test_mode;
 #define MAX_COMMAND_LENGTH 4096
 #define MAX_USERNAME_LENGTH 256
 #define MAX_PASSWORD_LENGTH 256
-#define SUDOSH_VERSION "1.5.2"
+#define SUDOSH_VERSION "1.5.3"
 #define INACTIVITY_TIMEOUT 300  /* 300 seconds (5 minutes) */
 
 /* Authentication cache constants */

--- a/src/utils.c
+++ b/src/utils.c
@@ -8,6 +8,9 @@
  */
 
 #include "sudosh.h"
+
+/* Global test mode flag */
+int test_mode = 0;
 #include <ctype.h>
 
 /* Global target user for -u option */


### PR DESCRIPTION
## 🚨 Critical Security Bugfix - v1.5.3

### Issue Fixed
Sudosh was allowing **any command** to be run when users had general sudo privileges, instead of enforcing specific command permissions from sudoers configuration. This is a **critical security vulnerability** that could lead to privilege escalation.

### Root Cause
The main command loop only checked if users had general sudo privileges (`has_sudo_privileges`) but never validated that the specific command being executed was allowed according to their sudoers configuration.

### Changes Made

#### 1. Added `check_command_permission()` function
- **Location**: `src/auth.c`
- **Purpose**: Uses `sudo -l -U username command` to check specific command permissions
- **Validation**: Properly validates that user can run the exact command requested
- **Security**: Returns 0 for denied commands, 1 for allowed commands

#### 2. Enhanced main command loop
- **Location**: `src/main.c`
- **Enhancement**: Added specific command permission check for users with sudo privileges
- **Validation**: Now validates each command against sudoers configuration
- **UX**: Provides clear error messages when commands are not permitted
- **Logging**: Logs security violations for unauthorized command attempts

#### 3. Comprehensive test suite
- **Location**: `tests/test_sudo_permission_enforcement.c`
- **Coverage**: Tests command permission checking function
- **Validation**: Validates sudo privilege enforcement
- **Edge Cases**: Tests safe command identification and error conditions
- **Integration**: Verifies complete validation flow

#### 4. Test infrastructure improvements
- **Global variable**: Added `test_mode` for non-interactive testing
- **Location**: Defined in `src/utils.c`, declared in `src/sudosh.h`
- **Purpose**: Enables CI/CD automation without user prompts

### Security Impact

- **🔴 CRITICAL**: Prevents privilege escalation through unrestricted command execution
- **🛡️ ENFORCEMENT**: Users with sudo privileges now limited to commands explicitly allowed in sudoers
- **⚖️ PRINCIPLE**: Maintains principle of least privilege
- **📋 AUDIT**: Provides proper audit trail for denied commands

### Testing Results

```
✅ All existing tests pass
✅ New permission enforcement test passes  
✅ Command validation working correctly
✅ Proper error messages and logging
✅ No regression in functionality
```

### Test Output
```
=== Sudo Permission Enforcement Tests ===
Testing command permission checking...
  Command permission for 'ls': ALLOWED
  Command permission for 'pwd': ALLOWED
  Command permission for 'systemctl restart sshd': DENIED
  Non-existent user permission check: PASS

✅ All sudo permission enforcement tests PASSED!
Sudosh properly enforces sudo configuration constraints.
```

### Version Bump
- **Version**: 1.5.2 → 1.5.3
- **Type**: Critical security bugfix release
- **Urgency**: **IMMEDIATE** - All users should upgrade

### Verification
- [x] Build succeeds with zero warnings
- [x] All existing tests pass
- [x] New security test passes
- [x] Manual testing confirms fix
- [x] No functional regressions

---

**This fix ensures sudosh properly respects sudo configuration constraints and only allows commands that are explicitly permitted for each user.**

**⚠️ SECURITY NOTICE**: This is a critical security update. All sudosh deployments should be updated immediately to prevent potential privilege escalation attacks.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author